### PR TITLE
fix to get attribute id dinamically

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -2,6 +2,9 @@
 namespace AccelaSearch\Search\Helper;
 
 use AccelaSearch\Search\Constants;
+use Magento\Catalog\Model\Product;
+use Magento\Eav\Api\AttributeRepositoryInterface;
+use Magento\Eav\Model\AttributeRepository;
 use Magento\Framework\App\Config;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\Exception\FileSystemException;
@@ -41,6 +44,10 @@ class Data extends AbstractHelper
      * @var Json
      */
     private $jsonSerializer;
+    /**
+     * @var AttributeRepositoryInterface
+     */
+    protected $attributeRepository;
 
     /**
      * Data constructor.
@@ -58,7 +65,8 @@ class Data extends AbstractHelper
         ResourceConnection $resource,
         DirectoryList $directoryList,
         Logger $logger,
-        Json $jsonSerializer
+        Json $jsonSerializer,
+        AttributeRepositoryInterface $attributeRepository
     )
     {
         $this->_storeManager = $storeManager;
@@ -66,7 +74,18 @@ class Data extends AbstractHelper
         $this->_directoryList = $directoryList;
         $this->_logger = $logger;
         $this->jsonSerializer = $jsonSerializer;
+        $this->_attributeRepository = $attributeRepository;
         parent::__construct($context);
+    }
+
+    /**
+     * @param $code
+     * @return int|null
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getAttributeIdByCode($code)
+    {
+        return $this->_attributeRepository->get(Product::ENTITY, $code)->getAttributeId();
     }
 
     /**

--- a/Model/FeedProducts.php
+++ b/Model/FeedProducts.php
@@ -231,17 +231,17 @@ class FeedProducts
 
             . // checking the product price on 'catalog_product_index_price' table
             "LEFT JOIN $tableCatalogProductEntityDecimal AS cped
-            ON cpe.entity_id = cped.entity_id AND cped.attribute_id = 77 "
+            ON cpe.entity_id = cped.entity_id AND cped.attribute_id = {$this->_helper->getAttributeIdByCode('price')} "
 
             . // checking the product stock on 'cataloginventory_stock_item' table
             "LEFT JOIN $tableCataloginventoryStockItem csi
             ON csi.product_id = cpe.entity_id ";
 
-            /*
-            . // checking the categories product on 'catalog_category_product' table
-            "JOIN $tableCatalogCategoryProduct as ccp
-            ON ccp.product_id = cpe.entity_id ";
-            */
+        /*
+        . // checking the categories product on 'catalog_category_product' table
+        "JOIN $tableCatalogCategoryProduct as ccp
+        ON ccp.product_id = cpe.entity_id ";
+        */
 
         // checking 'status' and 'visibility'
         $sqlFeedProductsSel .= "


### PR DESCRIPTION
Ciao, ho notato che c'era l'id attributo price hardcodato e non è sempre lo stesso in tutte le installazioni di magento, va ricavato dinamicamente. Spero di aver fatto cosa gradita.

Manuel